### PR TITLE
Make equipe.php photos responsive

### DIFF
--- a/site_pulse/css/style.css
+++ b/site_pulse/css/style.css
@@ -5138,8 +5138,8 @@ p {
 
 .team-image {
     position: relative;
-    height: 120px;
-    width: 120px;
+    width: clamp(110px, 28vw, 160px);
+    aspect-ratio: 1 / 1;
     margin: 1rem auto;
     border-radius: 50%;
     overflow: hidden;
@@ -5248,7 +5248,8 @@ p {
     }
     
     .team-image {
-        height: 250px;
+        width: clamp(120px, 45vw, 180px);
+        aspect-ratio: 1 / 1;
     }
     
     .team-content {


### PR DESCRIPTION
Make team photos responsive by using `clamp()` and `aspect-ratio` for scaling.

This change ensures team photos remain perfectly square and scale smoothly across all devices, addressing the user's request for improved responsiveness on `equipe.php`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d37e9e70-4d5e-4098-b4af-32e068ae36a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d37e9e70-4d5e-4098-b4af-32e068ae36a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

